### PR TITLE
Add better terminal colour support and add new domain commands

### DIFF
--- a/acquia_toolbelt.gemspec
+++ b/acquia_toolbelt.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "highline", "1.6.19"
   spec.add_runtime_dependency "faraday", "0.8.8"
   spec.add_runtime_dependency "json", "1.8.0"
+  spec.add_runtime_dependency "rainbow", "1.1.4"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/bin/acquia
+++ b/bin/acquia
@@ -5,6 +5,7 @@ require "netrc"
 require "highline/import"
 require "faraday"
 require "json"
+require "rainbow"
 
 class Acquia < Thor
   # A no_commands block is designed to show the methods that cannot be invoked
@@ -14,21 +15,21 @@ class Acquia < Thor
     #
     # Returns the coloured and formatted string.
     def success(text)
-      puts "\e[#32m#{text}\e[0m"
+      puts "#{text}".foreground(:green)
     end
 
     # Internal: Used for outputting a pretty error message.
     #
     # Returns the coloured and formatted string.
     def fail(text)
-      puts "\e[#31m#{text}\e[0m"
+      puts "#{text}".foreground(:red)
     end
 
     # Internal: Used for outputting a pretty info message.
     #
     # Returns the coloured and formatted string.
     def info(text)
-      puts "\e[#36m#{text}\e[0m"
+      puts "#{text}".foreground(:cyan)
     end
 
     # Internal: Create a request to the Acquia API.

--- a/bin/acquia
+++ b/bin/acquia
@@ -376,6 +376,24 @@ class Acquia < Thor
     end
   end
 
+  # Public: Add a domain to an environment.
+  #
+  # Returns a status message on successful addition.
+  desc "add-domain <subscription> <environment> <domain>", "Add a domain to an environment."
+  def add_domain(subscription, environment, domain)
+    add_domain = acquia_api_call "/sites/#{subscription}/envs/#{environment}/domains/#{domain}", "POST"
+    success "Domain #{domain} has been successfully added to #{environment}." if add_domain["id"]
+  end
+
+  # Public: Remove a domain from an environment.
+  #
+  # Returns a status message on successful deletion.
+  desc "delete-domain <subscription> <environment> <domain>", "Delete a domain from an environment."
+  def delete_domain(subscription, environment, domain)
+    delete_domain = acquia_api_call "/sites/#{subscription}/envs/#{environment}/domains/#{domain}", "DELETE"
+    success "Domain #{domain} has been successfully deleted from #{environment}." if delete_domain["id"]
+  end
+
   # Public: Clear a web cache on a domain.
   #
   # Send off a DELETE request to clear the web cache for a particular domain or

--- a/lib/acquia_toolbelt/version.rb
+++ b/lib/acquia_toolbelt/version.rb
@@ -1,3 +1,3 @@
 module AcquiaToolbelt
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,11 @@ $ acquia
 
 Commands:
   acquia add-database <subscription> <database>                          # Create a new database instance.
+  acquia add-domain <subscription> <environment> <domain>                # Add a domain to an environment.
   acquia copy-database <subscription> <database> <source> <destination>  # Copy a database one from environment to another.
   acquia copy-files <subscription> <source> <destination>                # Copy files from one environment to another.
   acquia delete-database <subscription> <database>                       # Remove all instances of a database.
+  acquia delete-domain <subscription> <environment> <domain>             # Delete a domain from an environment.
   acquia delete-svn-user <subscription> <userid>                         # Delete a SVN user.
   acquia help [COMMAND]                                                  # Describe available commands or one specific command
   acquia list-database-backups <subscription> <environment> <database>   # Get all backups for a database instance.
@@ -37,7 +39,7 @@ Commands:
   acquia list-subscriptions                                              # Find all subscriptions that you have access to.
   acquia list-svn-users <subscription>                                   # See all the SVN users on a subscription.
   acquia login                                                           # Login to your Acquia account.
-  acquia purge-domain <subscription>                                     # Clear the web cache of an environment or domain.
+  acquia purge-domain <subscription> <environment>                       # Clear the web cache of an environment or domain.
 ```
 
 ## Getting started


### PR DESCRIPTION
- Swapped to using the rainbow gem for the coloured terminal output as this already seems to fix the issue that Ubuntu users were encountering in #7.
- Added functionality for the add-domain and delete-domain commands via #6.
