### PR TITLE
Handle connection and auth errors better

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acquia_toolbelt (2.1.0)
+    acquia_toolbelt (2.2.0)
       faraday (= 0.8.8)
       highline (= 1.6.19)
       json (= 1.8.0)

--- a/lib/acquia_toolbelt/cli/api.rb
+++ b/lib/acquia_toolbelt/cli/api.rb
@@ -143,7 +143,9 @@ module AcquiaToolbelt
       #
       # Returns string of the message.
       def self.display_error(response)
-        "Oops, an error occurred!\n\nReason returned from the API: #{response["message"]}"
+        "Oops, an error occurred! Reason: #{response["message"]}"
+      end
+
       # Internal: Ensure the response returns a HTTP 200.
       #
       # If the response status isn't a HTTP 200, we need to find out why. This

--- a/lib/acquia_toolbelt/cli/api.rb
+++ b/lib/acquia_toolbelt/cli/api.rb
@@ -50,6 +50,7 @@ module AcquiaToolbelt
         case method
         when "GET"
           response = conn.get "#{endpoint_uri}/#{resource}.json"
+          is_successful_response? response
 
           if parse_request == true
             JSON.parse(response.body)
@@ -58,6 +59,7 @@ module AcquiaToolbelt
           end
         when "POST"
           response = conn.post "#{endpoint_uri}/#{resource}.json", data.to_json
+          is_successful_response? response
 
           if parse_request == true
             JSON.parse(response.body)
@@ -66,6 +68,7 @@ module AcquiaToolbelt
           end
         when "QUERY-STRING-POST"
           response = conn.post "#{endpoint_uri}/#{resource}.json?#{data[:key]}=#{data[:value]}", data.to_json
+          is_successful_response? response
 
           if parse_request == true
             JSON.parse(response.body)
@@ -74,6 +77,7 @@ module AcquiaToolbelt
           end
         when "DELETE"
           response = conn.delete "#{endpoint_uri}/#{resource}.json"
+          is_successful_response? response
 
           if parse_request == true
             JSON.parse(response.body)
@@ -140,6 +144,18 @@ module AcquiaToolbelt
       # Returns string of the message.
       def self.display_error(response)
         "Oops, an error occurred!\n\nReason returned from the API: #{response["message"]}"
+      # Internal: Ensure the response returns a HTTP 200.
+      #
+      # If the response status isn't a HTTP 200, we need to find out why. This
+      # helps identify the issues earlier on and will prevent extra API calls
+      # that won't complete.
+      #
+      # Returns false if the response code isn't a HTTP 200.
+      def self.is_successful_response?(response)
+        if response.status != 200
+          puts display_error(JSON.parse(response.body))
+          return
+        end
       end
     end
   end

--- a/lib/acquia_toolbelt/version.rb
+++ b/lib/acquia_toolbelt/version.rb
@@ -1,3 +1,3 @@
 module AcquiaToolbelt
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
Sometimes the requests cannot complete due to a number of factors such
as bad auth, wrong expected data, etc. and if that happens, the request
needs to terminate immediately instead of continuing on to fail.

This isn't a big deal just checking for a 200 at the moment as Acquia
do not utiltise status codes like 201 for newly created resources
however that will be something to keep an eye on in case it does happen.
